### PR TITLE
Fix `make bootstrap` error & Fix broken links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,5 @@ Server/InigoStatic/Local/*
 .terraform
 *.tfstate
 *.tfstate.backup
-*.ipkg
 !*Bootstrap.ipkg
-!./Inigo.ipkg
 !./Server/InigoServer/InigoServer.ipkg

--- a/Base/Color/Inigo.toml
+++ b/Base/Color/Inigo.toml
@@ -3,7 +3,7 @@ package="Color"
 version="0.0.1"
 
 description="Library for ANSI colors in your terminal"
-link="https://github.com/inigo/tree/master/Base/Color"
+link="https://github.com/idris-community/inigo/tree/master/Base/Color"
 readme="README.md"
 modules=["Color"]
 depends=["idris2", "contrib"] # TODO: How to rebuild when changes?

--- a/Base/Extra/Inigo.toml
+++ b/Base/Extra/Inigo.toml
@@ -3,7 +3,7 @@ package="Extra"
 version="0.0.3"
 
 description="Miscellaneous Extra Functions and Helpers for Idris2"
-link="https://github.com/inigo/tree/master/Base/Extra"
+link="https://github.com/idris-community/inigo/tree/master/Base/Extra"
 readme="README.md"
 modules=["Extra.Buffer", "Extra.Debug", "Extra.Either", "Extra.List", "Extra.Monad", "Extra.Op", "Extra.String"]
 depends=["idris2", "contrib"]

--- a/Base/Fmt/Inigo.toml
+++ b/Base/Fmt/Inigo.toml
@@ -3,7 +3,7 @@ package="Fmt"
 version="0.0.1"
 
 description="Dependently-typed String Formatter for Idris2"
-link="https://github.com/inigo/tree/master/Base/Fmt"
+link="https://github.com/idris-community/inigo/tree/master/Base/Fmt"
 readme="README.md"
 modules=["Fmt"]
 depends=["idris2", "contrib"]

--- a/Base/IdrTest/Inigo.toml
+++ b/Base/IdrTest/Inigo.toml
@@ -3,7 +3,7 @@ package="IdrTest"
 version="0.0.1"
 
 description="Unit-test framework for Idris2"
-link="https://github.com/inigo/tree/master/Base/IdrTest"
+link="https://github.com/idris-community/inigo/tree/master/Base/IdrTest"
 readme="README.md"
 modules=["IdrTest.Test", "IdrTest.Expectation"]
 depends=["idris2", "contrib"]

--- a/Base/Markdown/Inigo.toml
+++ b/Base/Markdown/Inigo.toml
@@ -3,7 +3,7 @@ package="Markdown"
 version="0.0.4"
 
 description="Markdown Parser and Renderer for Idris2"
-link="https://github.com/inigo/tree/master/Base/Markdown"
+link="https://github.com/idris-community/inigo/tree/master/Base/Markdown"
 readme="README.md"
 modules=["Markdown", "Markdown.Data", "Markdown.Format.Html"]
 depends=["idris2", "contrib"]

--- a/Base/SemVar/Inigo.toml
+++ b/Base/SemVar/Inigo.toml
@@ -3,7 +3,7 @@ package="SemVar"
 version="0.0.1"
 
 description="Semantic Version Parser and Satisfier"
-link="https://github.com/inigo/tree/master/Base/SemVar"
+link="https://github.com/idris-community/inigo/tree/master/Base/SemVar"
 readme="README.md"
 modules=["SemVar", "SemVar.Sat"]
 depends=["idris2", "contrib"]

--- a/Base/Toml/Inigo.toml
+++ b/Base/Toml/Inigo.toml
@@ -3,7 +3,7 @@ package="Toml"
 version="0.0.1"
 
 description="Toml Parser for Idris2"
-link="https://github.com/inigo/tree/master/Base/Toml"
+link="https://github.com/idris-community/inigo/tree/master/Base/Toml"
 readme="README.md"
 modules=["Toml"]
 depends=["idris2", "contrib"]

--- a/Inigo.ipkg
+++ b/Inigo.ipkg
@@ -1,0 +1,10 @@
+package Inigo
+
+modules = Client.Client
+depends = lib, prelude, contrib, base, idris2
+
+sourcedir = ""
+
+version = "0.0.1"
+main = Client.Client
+executable = inigo


### PR DESCRIPTION
1. Because of the lack of `Inigo.idr`, `make bootstrap` gives the following error:
```
/Library/Developer/CommandLineTools/usr/bin/make inigo
idris2 --build Inigo.ipkg --cg node
Uncaught error: File error (Inigo.ipkg): File Not Found
make[1]: *** [inigo] Error 1
make: *** [bootstrap] Error 2
```
2. Fix some broken links in toml files, such as https://github.com/inigo/tree/master/Base/Color.