### PR TITLE
[ new ] support for extra-deps

### DIFF
--- a/Base/Extra/Extra/List.idr
+++ b/Base/Extra/Extra/List.idr
@@ -83,7 +83,7 @@ replace l k v =
         Just (S k) =>
           (acc, Just k)
         _ =>
-          if isJust (find (== i) matches) then
+          if any (== i) matches then
             -- We need to insert a replacement and then skip N els
             (repl ++ acc, Just skipLen)
           else

--- a/Base/Extra/Extra/String.idr
+++ b/Base/Extra/Extra/String.idr
@@ -53,7 +53,7 @@ includesAny search =
   let
     searchChars = unpack search
   in
-    isJust . find (\c => c `elem` searchChars) . unpack
+     any (\c => c `elem` searchChars) . unpack
 
 export
 quote : String -> String

--- a/Base/IdrTest/IdrTest/Test.idr
+++ b/Base/IdrTest/IdrTest/Test.idr
@@ -93,7 +93,7 @@ filterTests tests =
   where
     hasOnly : List TestCase -> Bool
     hasOnly =
-      isJust . find (\(_, _, f) => Set.contains Only f)
+      any (\(_, _, f) => Set.contains Only f)
 
     filterSkips : TestCase -> Bool
     filterSkips (_, _, flags) =

--- a/Client/Action/Build.idr
+++ b/Client/Action/Build.idr
@@ -20,14 +20,14 @@ writeIPkgFile =
   do
     pkg <- Inigo.Async.Package.currPackage
     -- TODO: Only build if not exists ?
-    fs_writeFile iPkgFile (Package.Package.generateIPkg False pkg)
+    fs_writeFile iPkgFile (Package.Package.generateIPkg Nothing pkg)
     pure pkg
 
 export
 runBuild : CodeGen -> Package -> Promise ()
 runBuild codeGen pkg =
   do
-    ignore $ system "idris2" ["--build", iPkgFile, "--cg", toString codeGen] False True
+    ignore $ system "idris2" ["--build", iPkgFile, "--cg", toString codeGen] Nothing False True
 
 export
 build : CodeGen -> Promise ()

--- a/Client/Action/BuildDeps.idr
+++ b/Client/Action/BuildDeps.idr
@@ -5,7 +5,11 @@ import Data.String
 import Fmt
 import Inigo.Async.Base
 import Inigo.Async.FS
+import Inigo.Async.Package
 import Inigo.Async.Promise
+import Inigo.Package.Package
+import SemVar
+import System.Path
 
 export
 depsDir : String
@@ -15,13 +19,34 @@ buildIPkg : String -> Promise ()
 buildIPkg ipkg =
   do
     log (fmt "Compiling %s" ipkg)
-    ignore $ system "idris2" ["--build", ipkg] False True
+    ignore $ system "idris2" ["--build", ipkg] Nothing False True
     log (fmt "Compiled %s" ipkg)
 
 export
-buildDeps : Promise ()
-buildDeps =  
-  do
-    files <- fs_getFilesR depsDir
-    let ipkgs = filter (isSuffixOf ".ipkg") files
-    ignore $ all $ map buildIPkg ipkgs
+buildDeps : Bool -> Promise ()
+-- buildDeps =  
+--   do
+--     files <- fs_getFilesR depsDir
+--     let ipkgs = filter (isSuffixOf ".ipkg") files
+--     ignore $ all $ map buildIPkg ipkgs
+buildDeps dev = do
+    pkg <- currPackage
+    let allDeps = pkg.deps ++ if dev then pkg.devDeps else []
+    let depNames = map fst allDeps
+    ignore $ all $ map buildDep depNames
+  where
+    buildDep : List String -> Promise ()
+    buildDep dep = do
+        let ipkg = joinPath dep </> "Inigo.ipkg"
+        buildIPkg ipkg
+
+export
+buildExtraDeps : Promise ()
+buildExtraDeps = do
+    pkg <- currPackage
+    ignore $ all $ map buildExtraDep pkg.extraDeps
+  where
+    buildExtraDep : ExtraDep -> Promise ()
+    buildExtraDep (MkExtraDep _ _ url subFolders) = do
+        let ipkgs = (\f => genFolder url </> f </> "Inigo.ipkg") <$> subFolders
+        ignore $ all $ map buildIPkg ipkgs

--- a/Client/Action/CacheDeps.idr
+++ b/Client/Action/CacheDeps.idr
@@ -1,0 +1,41 @@
+module Client.Action.CacheDeps
+
+import Data.List
+import Inigo.Async.Base
+import Inigo.Async.FS
+import Inigo.Async.Promise
+import Inigo.Package.Package
+import Inigo.Package.JSON
+import Inigo.Paths
+import Language.JSON
+import SemVar
+
+export
+writeDepCache : List (String, Package) -> Promise ()
+writeDepCache pkgWithSrcs = fs_writeFile inigoDepPkgCache json
+  where
+    encodeWithSrc : (String, Package) -> JSON
+    encodeWithSrc (src, pkg) = JObject
+        [ ("src", JString src)
+        , ("package", encodePackage pkg)
+        ]
+    json : String
+    json = show $ JArray $ encodeWithSrc <$> pkgWithSrcs
+
+export
+readDepCache : Promise (List (String, Package))
+readDepCache = do
+    inp <- fs_readFile inigoDepPkgCache
+    let Just (JArray json) = parse inp
+        | _ => reject "Corrupt dependency cache (\{inigoDepPkgCache}) (not an array)"
+    let Just pkgWithSrc = the (Maybe (List (String, Package))) $ traverse decodeWithSrc json
+        | _ => reject "Corrupt dependency cache (\{inigoDepPkgCache}) (couldn't parse packages)"
+    pure pkgWithSrc
+  where
+    decodeWithSrc : JSON -> Maybe (String, Package)
+    decodeWithSrc (JObject kvs) = do
+        JString src <- lookup "src" kvs
+            | _ => Nothing
+        pkg <- lookup "package" kvs >>= parsePackage
+        pure (src, pkg)
+    decodeWithSrc _ = Nothing

--- a/Client/Action/Clean.idr
+++ b/Client/Action/Clean.idr
@@ -1,13 +1,13 @@
 module Client.Action.Clean
 
 import Client.Action.Build
-import Client.Action.BuildDeps
 import Data.List
 import Data.String
 import Inigo.Async.Base
 import Inigo.Async.Promise
 import Inigo.Async.FS
 import Inigo.Package.Package
+import Inigo.Paths
 
 cleanIPkg : String -> Promise ()
 cleanIPkg ipkg =
@@ -19,8 +19,8 @@ clean deps =
   do
     ignore writeIPkgFile
     ignore $ cleanIPkg iPkgFile
-    when (deps && !(fs_exists depsDir)) $
+    when (deps && !(fs_exists inigoDepDir)) $
       do
-        files <- fs_getFilesR depsDir
+        files <- fs_getFilesR inigoDepDir
         let ipkgs = filter (isSuffixOf ".ipkg") files
         ignore $ all $ map cleanIPkg ipkgs

--- a/Client/Action/Clean.idr
+++ b/Client/Action/Clean.idr
@@ -11,7 +11,7 @@ import Inigo.Package.Package
 
 cleanIPkg : String -> Promise ()
 cleanIPkg ipkg =
-  ignore $ system "idris2" ["--clean", ipkg] False True
+  ignore $ system "idris2" ["--clean", ipkg] Nothing False True
 
 export
 clean : Bool -> Promise ()

--- a/Client/Action/FetchDeps.idr
+++ b/Client/Action/FetchDeps.idr
@@ -1,6 +1,7 @@
 module Client.Action.FetchDeps
 
 import Client.Action.BuildDeps
+import Client.Action.CacheDeps
 import Client.Action.Pull
 import Client.Server
 import Data.List
@@ -14,10 +15,10 @@ import Inigo.Async.Package
 import Inigo.Async.Promise
 import Inigo.Package.Package
 import Inigo.Package.PackageDeps
+import Inigo.Paths
 import Inigo.Util.Url.Url
 import SemVar
 import SemVar.Sat
-import System.Path
 
 getPackageDepTree : Server -> String -> String -> Promise PackageDepTree
 getPackageDepTree server packageNS packageName =
@@ -88,24 +89,61 @@ fetchDeps server includeDevDeps build =
           do
             pull server packageNS packageName (Just version)
 
+||| Get all elems of the left list not present in the right list
+total
+difference : Eq a => List a -> List a -> List a
+difference xs [] = xs
+difference xs (y :: ys) = difference (delete y xs) ys
+
 export
 fetchExtraDeps : Bool -> Bool -> Promise ()
 fetchExtraDeps devDeps build = do
     pkg <- currPackage
-    ignore $ all $ fetchExtraDep <$> pkg.extraDeps
+    deps <- fetchDeps [] pkg.extraDeps
+    pkgs <- foldlM getExtraDepPkg [] deps
+    writeDepCache pkgs
   where
-    genIPkg : String -> String -> Promise ()
+    getSubDirPkg : String -> List (String, Package) -> String -> Promise (List (String, Package))
+    getSubDirPkg depDir pkgs subDir = do
+        let srcDir = inigoDepDir </> depDir </> subDir
+        pkg <- readPackage $ srcDir </> inigoTomlPath
+        if any ((== pkg) . snd) pkgs
+            then pure pkgs
+            else pure ((srcDir, pkg) :: pkgs)
+
+    getExtraDepPkg : List (String, Package) -> ExtraDep -> Promise (List (String, Package))
+    getExtraDepPkg pkgs dep@(MkExtraDep _ _ _ subDirs) =
+        foldlM (getSubDirPkg $ getExtraDepDir dep) pkgs subDirs
+
+    genIPkg : String -> String -> Promise Package
     genIPkg dest subDir = do
         let buildDir = joinPath (".." <$ splitPath (dest </> subDir)) </> "build"
         let toml = dest </> subDir </> "Inigo.toml"
         let iPkgFile = dest </> subDir </> "Inigo.ipkg"
         pkg <- readPackage toml
-        log "Writing \{iPkgFile}..."
         fs_writeFile iPkgFile $ generateIPkg (Just buildDir) pkg
+        pure pkg
 
-    fetchExtraDep : ExtraDep -> Promise ()
-    fetchExtraDep (MkExtraDep Git commit url subDirs) = do
-        let dest = "Deps" </> genFolder url
+    fetchExtraDep : ExtraDep -> Promise (List Package)
+    fetchExtraDep pkg@(MkExtraDep Git commit url subDirs) = do
+        let dest = inigoDepDir </> getExtraDepDir pkg
         log "Downloading package from \"\{url}\""
         ignore $ git_downloadTo url (Just commit) dest
-        traverse_ (genIPkg dest) subDirs
+        traverse (genIPkg dest) subDirs
+
+    fetchDeps : List ExtraDep -> List ExtraDep -> Promise (List ExtraDep) -- if this is too slow, use SortedSet
+    fetchDeps done [] = pure done
+    fetchDeps done (MkExtraDep _ _ _ [] :: todo) = fetchDeps done todo
+    fetchDeps done (pkg@(MkExtraDep Git commit url subDirs0) :: todo) = case find (eqIgnoreSubDirs pkg) done of
+        Nothing => do -- doesn't exist yet, download and add dependencies
+            pkgs <- fetchExtraDep pkg
+            let todo' = foldl (\acc, pkg => pkg.extraDeps ++ acc) todo pkgs
+            fetchDeps (pkg :: done) todo'
+        Just pkg@(MkExtraDep Git commit url subDirs1) => case difference subDirs0 subDirs1 of
+            [] => fetchDeps done todo -- no missing subdirs, move on
+            missing => do
+                let dest = inigoDepDir </> getExtraDepDir pkg
+                pkgs <- traverse (genIPkg dest) missing
+                let todo' = foldl (\acc, pkg => pkg.extraDeps ++ acc) todo pkgs
+                let done' = MkExtraDep Git commit url (missing ++ subDirs0) :: filter (not . eqIgnoreSubDirs pkg) done
+                fetchDeps done' todo

--- a/Client/Action/Pull.idr
+++ b/Client/Action/Pull.idr
@@ -48,4 +48,4 @@ pull server packageNS packageName maybeVersion =
     extractArchive archive depPath
     let iPkgFile = depPath </> "Inigo.ipkg"
     log (fmt "Writing %s..." iPkgFile)
-    fs_writeFile iPkgFile (Package.Package.generateIPkg True pkg)
+    fs_writeFile iPkgFile (Package.Package.generateIPkg (Just "../../../build") pkg)

--- a/Client/Action/Test.idr
+++ b/Client/Action/Test.idr
@@ -14,4 +14,4 @@ test codeGen =
   do
     pkg <- Build.writeIPkgFile
     log (fmt "Running tests...")
-    ignore $ system "idris2" ["--find-ipkg", "Test/Suite.idr", "--cg", CodeGen.toString codeGen, "-x", "suite"] True True
+    ignore $ system "idris2" ["--find-ipkg", "Test/Suite.idr", "--cg", CodeGen.toString codeGen, "-x", "suite"] Nothing True True

--- a/Client/Client.idr
+++ b/Client/Client.idr
@@ -79,7 +79,7 @@ getAction ["extract", archiveFile, outPath] =
 
 getAction ("build-deps" :: args) =
   let
-    dev = isJust $ find (== "--dev") args
+    dev = any (== "--dev") args
   in
     Just (BuildDeps dev)
 
@@ -112,8 +112,8 @@ getAction ("exec" :: args) =
 
 getAction ("fetch-deps" :: serverName :: extraArgs) =
   let
-    build = not $ isJust $ find (== "--no-build") extraArgs
-    includeDevDeps = isJust $ find (== "--dev") extraArgs
+    build = not $ any (== "--no-build") extraArgs
+    includeDevDeps = any (== "--dev") extraArgs
   in
     fetchDepsAction serverName includeDevDeps build
 

--- a/Inigo/Archive/Path.idr
+++ b/Inigo/Archive/Path.idr
@@ -4,7 +4,7 @@ import Data.List
 import Data.String
 import Extra.String
 import Inigo.Package.Package
-import System.Path
+import Inigo.Paths
 
 isIPkg : String -> Bool
 isIPkg =
@@ -16,7 +16,7 @@ isBuild =
 
 isDep : String -> Bool
 isDep =
-  isInfixOf "/Deps/"
+  isInfixOf inigoDepDir
 
 isDisallowed : String -> Bool
 isDisallowed x =
@@ -33,4 +33,4 @@ depPath pkg =
   let
     modPath = joinPath (split '.' (package pkg))
   in
-    "Deps" </> (ns pkg) </> modPath
+    inigoDepDir </> (ns pkg) </> modPath

--- a/Inigo/Async/Base.idr
+++ b/Inigo/Async/Base.idr
@@ -1,5 +1,6 @@
 module Inigo.Async.Base
 
+import Data.Maybe
 import Inigo.Async.Promise
 import Inigo.Async.Util
 
@@ -12,8 +13,8 @@ reject__prim : String -> promise a
 %foreign (promisifyResolve "null" "(text)=>console.log(text)")
 log__prim : String -> promise ()
 
-%foreign (promisifyPrim (toArray "(cmd,args,detached,verbose)=>new Promise((resolve,reject)=>{let opts={detached:detached===1n, stdio: ['ignore', process.stdout, process.stderr]};require('child_process').spawn(cmd, toArray(args), opts).on('close', (code) => resolve(code))})"))
-system__prim : String -> List String -> Int -> Int -> promise Int
+%foreign (promisifyPrim (toArray "(cmd,args,workDir,detached,verbose)=>new Promise((resolve,reject)=>{let opts={detached:detached===1n, stdio: ['ignore', process.stdout, process.stderr],cwd:workDir};require('child_process').spawn(cmd, toArray(args), opts).on('close', (code) => resolve(code))})"))
+system__prim : String -> List String -> String -> Int -> Int -> promise Int
 
 %foreign (promisifyPrim (toArray "(cmd,args,detached,verbose)=>new Promise((resolve,reject)=>{let opts={detached:detached===1n, stdio: 'inherit'};require('child_process').spawn(cmd, toArray(args), opts).on('close', (code) => resolve(code))})"))
 systemWithStdIO__prim : String -> List String -> Int -> Int -> promise Int
@@ -34,9 +35,9 @@ log text =
   promisify (log__prim text)
 
 export
-system : String -> List String -> Bool -> Bool -> Promise Int
-system cmd args detached verbose =
-  promisify (system__prim cmd args (boolToInt detached) (boolToInt verbose))
+system : String -> List String -> Maybe String -> Bool -> Bool -> Promise Int
+system cmd args cwd detached verbose =
+  promisify (system__prim cmd args (fromMaybe "" cwd) (boolToInt detached) (boolToInt verbose))
 
 export
 systemWithStdIO : String -> List String -> Bool -> Bool -> Promise Int

--- a/Inigo/Async/Base.idr
+++ b/Inigo/Async/Base.idr
@@ -3,6 +3,7 @@ module Inigo.Async.Base
 import Data.Maybe
 import Inigo.Async.Promise
 import Inigo.Async.Util
+import Inigo.Paths
 
 %foreign (promisifyPrim "()=>new Promise((resolve,reject)=>{})")
 never__prim : promise ()
@@ -33,6 +34,10 @@ export
 log : String -> Promise ()
 log text =
   promisify (log__prim text)
+
+export
+debugLog : String -> Promise ()
+debugLog text = when DEBUG $ log text
 
 export
 system : String -> List String -> Maybe String -> Bool -> Bool -> Promise Int

--- a/Inigo/Async/Base.idr
+++ b/Inigo/Async/Base.idr
@@ -13,10 +13,10 @@ reject__prim : String -> promise a
 %foreign (promisifyResolve "null" "(text)=>console.log(text)")
 log__prim : String -> promise ()
 
-%foreign (promisifyPrim (toArray "(cmd,args,workDir,detached,verbose)=>new Promise((resolve,reject)=>{let opts={detached:detached===1n, stdio: ['ignore', process.stdout, process.stderr],cwd:workDir};require('child_process').spawn(cmd, toArray(args), opts).on('close', (code) => resolve(code))})"))
+%foreign (promisifyPrim (toArray "(cmd,args,workDir,detached,verbose)=>new Promise((resolve,reject)=>{let opts={detached:detached===1n, stdio: ['ignore', process.stdout, process.stderr],cwd:workDir};require('child_process').spawn(cmd, toArray(args), opts).on('close', (code) => resolve(BigInt(code)))})"))
 system__prim : String -> List String -> String -> Int -> Int -> promise Int
 
-%foreign (promisifyPrim (toArray "(cmd,args,detached,verbose)=>new Promise((resolve,reject)=>{let opts={detached:detached===1n, stdio: 'inherit'};require('child_process').spawn(cmd, toArray(args), opts).on('close', (code) => resolve(code))})"))
+%foreign (promisifyPrim (toArray "(cmd,args,detached,verbose)=>new Promise((resolve,reject)=>{let opts={detached:detached===1n, stdio: 'inherit'};require('child_process').spawn(cmd, toArray(args), opts).on('close', (code) => resolve(BigInt(code)))})"))
 systemWithStdIO__prim : String -> List String -> Int -> Int -> promise Int
 
 export

--- a/Inigo/Async/FS.idr
+++ b/Inigo/Async/FS.idr
@@ -21,6 +21,9 @@ fs_writeFileBuf__prim : String -> Buffer -> promise ()
 %foreign (promisifyPrim "(path,r)=>require('fs').promises.mkdir(path,{recursive: r === 1n})")
 fs_mkdir__prim : String -> Int -> promise ()
 
+%foreign (promisifyPrim "(path,r)=>require('fs').promises.rmdir(path,{recursive: r === 1n})")
+fs_rmdir__prim : String -> Int -> promise ()
+
 %foreign (promisifyPrim "(path)=>require('fs').promises.readdir(path).then(__prim_js2idris_array)")
 fs_getFiles__prim : String -> promise (List String)
 
@@ -54,6 +57,11 @@ export
 fs_mkdir : Bool -> String -> Promise ()
 fs_mkdir recursive path =
   promisify (fs_mkdir__prim path (boolToInt recursive))
+
+export
+fs_rmdir : Bool -> String -> Promise ()
+fs_rmdir recursive path =
+  promisify (fs_rmdir__prim path (boolToInt recursive))
 
 export
 fs_getFiles : String -> Promise (List String)

--- a/Inigo/Async/Git.idr
+++ b/Inigo/Async/Git.idr
@@ -1,0 +1,22 @@
+module Inigo.Async.Git
+
+import Inigo.Async.Base
+import Inigo.Async.Promise
+import Inigo.Async.FS
+import System.Path
+
+||| Download a git repository optionally specifying the commit, then remove the .git folder
+||| Returns `True` iff the file already exists.
+export
+git_downloadTo : (url : String) -> (commit : Maybe String) -> (dest : String) -> Promise Bool
+git_downloadTo url commit dest = do
+    case !(fs_exists dest) of
+        False => do
+            ignore $ system "git" ["clone", "-q", "--progress", "--recurse-submodules", url, dest] Nothing False False
+            maybe
+                (pure ())
+                (\com => ignore $ system "git" ["checkout", "-q", com] (Just dest) False False)
+                commit
+            fs_rmdir True (dest </> ".git")
+            pure False
+        True => pure True

--- a/Inigo/Package/ExtraDep.idr
+++ b/Inigo/Package/ExtraDep.idr
@@ -1,0 +1,81 @@
+module Inigo.Package.ExtraDep
+
+import Data.List1
+import Data.String
+import Extra.String
+import Inigo.Package.ParseHelpers
+import Toml
+
+-- TODO: Other methods?
+public export
+data Download
+    = Git
+
+public export
+DownloadInfo : Download -> Type
+DownloadInfo Git = String -- commit
+
+export
+parseDownload : Toml -> Either String Download
+parseDownload toml = case get ["download"] toml of
+    Just (Str "git") => Right Git
+    Just (Str val) => Left "Invalid download method: \{val}"
+    Just val => Left "Inavlid value for field download: \{show val}"
+    Nothing => Left "Missing field download"
+
+public export
+record ExtraDep where
+    constructor MkExtraDep
+    download : Download
+    downloadInfo : DownloadInfo download
+    url : String
+    subFolders : List String
+
+export
+Show ExtraDep where
+    show (MkExtraDep Git commit url subFolders) =
+        "MkExtraDep{download=git, download-info=\"\{commit}\", url=\"\{url}\", subFolders=\{show subFolders}"
+
+export
+Eq ExtraDep where
+    MkExtraDep Git commit0 url0 subFolders0 == MkExtraDep Git commit1 url1 subFolders1 =
+        commit0 == commit1 && url0 == url1 && subFolders0 == subFolders1
+    _ == _ = False
+
+export
+toToml : List ExtraDep -> Toml
+toToml deps = [(["extra-dep"], ArrTab $ depToToml <$> deps)]
+  where
+    depToToml : ExtraDep -> Toml
+    depToToml (MkExtraDep Git commit url subFolders) =
+        [ (["download"], Str "git")
+        , (["commit"], Str commit)
+        , (["url"], Str url)
+        , (["sub-folders"], Lst (Str <$> subFolders))
+        ]
+
+export
+parseExtraDeps : Toml -> Either String (List ExtraDep)
+parseExtraDeps toml = case get ["extra-dep"] toml of
+    Nothing => Right []
+    Just (ArrTab deps) => foldlM extraDep [] deps
+    Just val => Left "Invalid extra dependency found: \{show val}"
+  where
+    extraDep : List ExtraDep -> Toml -> Either String (List ExtraDep)
+    extraDep deps toml = do
+        url <- string ["url"] toml
+        subFolders <- withDefault [""] $ listStr ["sub-folders"] toml
+        download <- parseDownload toml
+        case download of
+            Git => do
+                commit <- string ["commit"] toml
+                pure $ MkExtraDep Git commit url subFolders :: deps
+
+export
+genFolder : String -> String
+genFolder = concat . map escapeChar . unpack
+  where
+    escapeChar : Char -> String
+    escapeChar c = if isAlphaNum c
+        then cast c
+        else "_" ++ show (ord c)

--- a/Inigo/Package/JSON.idr
+++ b/Inigo/Package/JSON.idr
@@ -1,0 +1,118 @@
+||| Module for serialising and deserialising Inigo packages
+module Inigo.Package.JSON
+
+import Data.List
+import Data.Maybe
+import Inigo.Package.Package
+import Language.JSON
+import SemVar
+
+extraDepToJSON : ExtraDep -> JSON
+extraDepToJSON (MkExtraDep Git commit url subDirs) = JObject
+    [ ("download", JString "git")
+    , ("commit", JString commit)
+    , ("url", JString url)
+    , ("subDirs", JArray (JString <$> subDirs))
+    ]
+
+nullable : Lazy (a -> JSON) -> Maybe a -> JSON
+nullable = maybe JNull
+
+export
+encodePackage : Package -> JSON
+encodePackage pkg = JObject
+    [ ("ns", JString pkg.ns)
+    , ("package", JString pkg.package)
+    , ("version", JString (show pkg.version))
+    , ("description", nullable JString pkg.description)
+    , ("link", nullable JString pkg.link)
+    , ("readme", nullable JString pkg.readme)
+    , ("modules", JArray (JString <$> pkg.modules))
+    , ("depends", JArray (JString <$> pkg.depends))
+    , ("license", nullable JString pkg.license)
+    , ("sourcedir", JString pkg.sourcedir)
+    , ("main", nullable JString pkg.main)
+    , ("executable", nullable JString pkg.executable)
+    , ("deps", JArray (mkDep <$> pkg.deps))
+    , ("dev-deps", JArray (mkDep <$> pkg.devDeps))
+    , ("extra-deps", JArray (extraDepToJSON <$> pkg.extraDeps))
+    ]
+  where
+    mkDep : (List String, Requirement) -> JSON
+    mkDep (ns, semvar) = JObject
+        [ ("name", JArray (JString <$> ns))
+        , ("semvar", JString (show semvar))
+        ]
+
+export
+encodeAsJSON : Package -> String
+encodeAsJSON = show . JSON.encodePackage
+
+namespace Parse
+
+    key : String -> JSON -> Maybe JSON
+    key k (JObject kvs) = lookup k kvs
+    key _ _ = Nothing
+
+    string : JSON -> Maybe String
+    string (JString str) = Just str
+    string _ = Nothing
+
+    stringKey : String -> JSON -> Maybe String
+    stringKey k json = key k json >>= \case
+        JString str => Just str
+        _ => Nothing
+
+    arrayKey : String -> JSON -> Maybe (List JSON)
+    arrayKey k json = key k json >>= \case
+        JArray arr => Just arr
+        _ => Nothing
+
+    nullable : Maybe a -> Maybe (Maybe a)
+    nullable (Just x) = Just (Just x)
+    nullable Nothing = Just Nothing
+
+    parseExtraDep : JSON -> Maybe ExtraDep
+    parseExtraDep json = do
+        url <- stringKey "url" json
+        subDirs <- arrayKey "subDirs" json >>= traverse string
+        download <- stringKey "download" json
+        case download of
+            "git" => do
+                commit <- stringKey "commit" json
+                Just $ MkExtraDep Git commit url subDirs
+            _ => Nothing
+
+    export
+    parsePackage : JSON -> Maybe Package
+    parsePackage json = do
+        ns <- stringKey "ns" json
+        package <- stringKey "package" json
+        version <- stringKey "version" json >>= parseVersion
+        description <- nullable $ stringKey "description" json
+        link <- nullable $ stringKey "link" json
+        readme <- nullable $ stringKey "readme" json
+        modules <- arrayKey "modules" json >>= traverse string
+        depends <- arrayKey "depends" json >>= traverse string
+        license <- nullable $ stringKey "license" json
+        sourcedir <- stringKey "sourcedir" json
+        main <- nullable $ stringKey "main" json
+        executable <- nullable $ stringKey "executable" json
+        deps <- arrayKey "deps" json >>= traverse parseDep
+        devDeps <- arrayKey "dev-deps" json >>= traverse parseDep
+        extraDeps <- arrayKey "extra-deps" json >>= traverse parseExtraDep
+        Just $ MkPackage
+            { ns, package, version, description, link, readme
+            , modules, depends, license, sourcedir
+            , main, executable, deps, devDeps, extraDeps
+            }
+      where
+        parseDep : JSON -> Maybe (List String, Requirement)
+        parseDep json = do
+            ns <- arrayKey "name" json >>= traverse string
+            var <- stringKey "semvar" json >>= parseRequirement
+            Just (ns, var)
+
+export
+decodeJSON : String -> Maybe Package
+decodeJSON = parse >=> parsePackage

--- a/Inigo/Paths.idr
+++ b/Inigo/Paths.idr
@@ -1,0 +1,27 @@
+module Inigo.Paths
+
+import public System.Path
+
+export
+inigoTomlPath : String
+inigoTomlPath = "Inigo.toml"
+
+export
+inigoIPkgPath : String
+inigoIPkgPath = "Inigo.ipkg"
+
+export
+inigoWorkDir : String
+inigoWorkDir = ".inigo-work"
+
+export
+inigoDepDir : String
+inigoDepDir = inigoWorkDir </> "deps"
+
+export
+inigoDepPkgCache : String
+inigoDepPkgCache = inigoWorkDir </> "deps.cache"
+
+export
+DEBUG : Bool
+DEBUG = True


### PR DESCRIPTION
This adds support for deps outside of the ones on inigo.pm, for now any git repo.

example usage
```toml
# Inigo.toml
...

[[extra-dep]]
download = "git"
commit = "624eb9a0e15f8eb40375355efd10117cdbcc0c8a"
url = "https://github.com/idris-community/inigo.git"
sub-folders = ["Base/Color", "Base/Fmt"]
```
This will give access to the `Base.Color` and `Base.Fmt` packages available at https://github.com/idris-community/inigo at the specified commit. You must provide a commit (or tag or nothing because I don't sanitise it yet!).