### PR TITLE
Templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ Server/InigoStatic/Local/*
 !golden/tests.ipkg
 output
 failures
+golden/**/Inigo.ipkg

--- a/Client/Action/BuildDeps.idr
+++ b/Client/Action/BuildDeps.idr
@@ -18,7 +18,7 @@ buildIPkg : String -> Promise ()
 buildIPkg path =
   do
     log (fmt "Compiling %s" (path </> inigoIPkgPath))
-    debugLog "\{path}$ idris2 --build \{inigoIPkgPath}"
+    debugLog "[\{path}]$ idris2 --build \{inigoIPkgPath}"
     0 <- system "idris2" ["--build", inigoIPkgPath] (Just path) False True
         | errno => reject "idris2 build error: \{show errno}"
     log (fmt "Compiled %s" (path </> inigoIPkgPath))

--- a/Client/Action/Init.idr
+++ b/Client/Action/Init.idr
@@ -6,23 +6,27 @@ import Fmt
 import Inigo.Async.Base
 import Inigo.Async.FS
 import Inigo.Async.Promise
+import Inigo.Template
 import System.Path
 
 export
-init : Skeleton -> String -> String -> Promise ()
-init skeleton packageNS packageName =
-  do
-    ignore $ all $ map writeTmplFile (getFiles skeleton (packageNS, packageName))
-    log (fmt "Successfully built %s" (toString skeleton))
+init :
+    String -> -- template
+    String -> -- package namespace
+    String -> -- package name
+    Promise ()
+init tmplFile packageNS packageName = do
+    tmplInp <- fs_readFile tmplFile
+    tmpl <- liftEither $ runTemplate packageNS packageName tmplFile tmplInp
+    ignore $ all $ map writeTmplFile tmpl
+    log (fmt "Successfully built %s" tmplFile)
   where
     ensureParent : String -> Promise ()
     ensureParent path = case parent path of
-                          Just parentPath => unless (parentPath == "") $ fs_mkdir True parentPath
-                          Nothing => pure ()
+        Just parentPath => unless (parentPath == "") $ fs_mkdir True parentPath
+        Nothing => pure ()
 
-    writeTmplFile : (List String, String) -> Promise ()
-    writeTmplFile (path, contents) =
-      do
-        let path = joinPath path
+    writeTmplFile : (String, String) -> Promise ()
+    writeTmplFile (path, contents) = do
         ensureParent path
         fs_writeFile path contents

--- a/Inigo/Template.idr
+++ b/Inigo/Template.idr
@@ -1,0 +1,141 @@
+module Inigo.Template
+
+import Data.List1
+import Data.SnocList
+import Data.String
+import Debug.Trace
+
+public export
+record Pos where
+    constructor MkPos
+    line : Int
+    col : Int
+
+Show Pos where
+    show pos = "\{show pos.line}:\{show pos.col}"
+
+initPos : Pos
+initPos = MkPos 1 1
+
+nextChar : Pos -> Pos
+nextChar = record { col $= (+ 1) }
+
+nextLine : Pos -> Pos
+nextLine = record { line $= (+ 1), col = 1 }
+
+advance : Char -> Pos -> Pos
+advance '\n' = nextLine
+advance _ = nextChar
+
+data TempVar
+    = Package
+    | Namespace
+    | File String
+
+data TempPart : Type where
+    Var : TempVar -> TempPart
+    Text : String -> TempPart
+
+data TempState : Type where
+    InText : SnocList Char -> TempState
+    InVar : SnocList Char -> TempState
+    Escape : TempState
+
+initState : TempState
+initState = InText [<]
+
+unknownVar : Either String a
+unknownVar = Left "Unknown variable"
+
+parseVar : List Char -> Maybe TempVar
+parseVar ['P', 'a', 'c', 'k', 'a', 'g', 'e'] = Just Package
+parseVar ['N', 'a', 'm', 'e', 's', 'p', 'a', 'c', 'e'] = Just Namespace
+parseVar ('f' :: 'i' :: 'l' :: 'e' :: ' ' :: file) = Just $ File $ fastPack file
+parseVar _ = Nothing
+
+makeText : SnocList TempPart -> SnocList Char -> SnocList TempPart
+makeText acc [<] = acc
+makeText acc xs = acc :< Text (fastPack $ xs <>> [])
+
+cleanStart : List TempPart -> List TempPart
+cleanStart (Text t :: xs) = if "\n" `isPrefixOf` t
+    then Text (assert_total $ strSubstr 1 (cast (length t) - 1) t) :: xs
+    else Text t :: xs
+cleanStart xs = xs
+
+cleanEnd : SnocList TempPart -> SnocList TempPart
+cleanEnd (xs :< Text t) = if "\n" `isSuffixOf` t
+    then xs :< Text (assert_total $ strSubstr 0 (cast (length t) - 1) t)
+    else xs :< Text t
+cleanEnd xs = xs
+
+parse :
+    TempState -> -- state
+    List Char -> -- input
+    SnocList TempPart -> -- accumulator
+    Pos -> -- position
+    Either (Pos, String) (SnocList TempPart)
+parse (InText xs) [] acc pos = Right $ makeText acc xs
+parse (InText xs) ('\\' :: ys) acc pos = parse Escape ys (makeText acc xs) (nextChar pos)
+parse (InText xs) (x :: ys) acc pos = parse (InText $ xs :< x) ys acc (advance x pos)
+
+parse (InVar xs) [] acc pos = Left (pos, "Missing closing brace")
+parse (InVar xs) ('}' :: ys) acc pos =
+    let xs' = xs <>> []
+     in case parseVar xs' of
+        Nothing => Left (pos, "Unknown variable: \{fastPack xs'}")
+        Just var@(File _) => parse initState ys (cleanEnd acc :< Var var) (nextChar pos)
+        Just var => parse initState ys (acc :< Var var) (nextChar pos)
+parse (InVar xs) (x :: ys) acc pos = parse (InVar $ xs :< x) ys acc (advance x pos)
+
+parse Escape [] acc pos = Left (pos, "Trailing escape character")
+parse Escape ('\\' :: xs) acc pos = parse initState xs (acc :< Text "\\") (nextChar pos)
+parse Escape ('{' :: xs) acc pos = parse (InVar [<]) xs acc (nextChar pos)
+parse Escape (x :: xs) acc pos = Left (pos, "Unknown escape character: \{show x}")
+
+seperateFiles :
+    SnocList TempPart -> -- input
+    List TempPart -> -- accumulator for the file
+    List (String, List TempPart) -> -- accumulator for the entire template
+    Either String (List (String, List TempPart))
+seperateFiles [<] _ acc = Right acc
+seperateFiles (sx :< Var (File fp)) file acc = seperateFiles sx [] ((fp, cleanStart file) :: acc)
+seperateFiles (sx :< x) xs ys = seperateFiles sx (x :: xs) ys
+
+parameters (ns, pkg : String)
+
+    renderVar : TempVar -> Either String String
+    renderVar Package = Right pkg
+    renderVar Namespace = Right ns
+    renderVar (File x) = Left "Internal Error: Unexpected \\{file ...}"
+
+    renderTemplate :
+        List TempPart -> -- template
+        SnocList String -> -- accumulator
+        Either String (SnocList String)
+    renderTemplate [] acc = Right acc
+    renderTemplate (Var x :: xs) acc = case renderVar x of
+        Left err => Left err
+        Right v => renderTemplate xs (acc :< v)
+    renderTemplate (Text x :: xs) acc = renderTemplate xs (acc :< x)
+
+    render :
+        List (String, List TempPart) ->
+        List (String, String) ->
+        Either String (List (String, String))
+    render [] acc = Right acc
+    render ((fp, temp) :: ts) acc = case renderTemplate temp [<] of
+        Left err => Left err
+        Right res => render ts $ (fp, fastConcat $ res <>> []) :: acc
+
+    export
+    runTemplate :
+        String -> -- filepath
+        String -> -- input
+        Either String (List (String, String))
+    runTemplate fp inp0 = do
+        let Right inp1 = parse initState (fastUnpack inp0)  [<] initPos
+            | Left (pos, err) => Left $ "Parse error in \{fp}, at \{show pos}: \{err}"
+        let Right inp2 = seperateFiles inp1 [] []
+            | Left err => Left $ "Parse error in \{fp}: \{err}"
+        render inp2 []

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ test :
 
 clean :
 	idris2 --clean Inigo.ipkg
+	idris2 --clean idrall/idrall.ipkg
 
 testbin :
 	${MAKE} -C golden testbin
@@ -71,5 +72,5 @@ testbin :
 golden : testbin
 	${MAKE} -C golden only=$(only)
 
-distclean :
+distclean : clean
 	$(RM) -r build

--- a/golden/inigo/test001/expected
+++ b/golden/inigo/test001/expected
@@ -8,7 +8,7 @@ usage: Inigo <command> <...args>
 	exec <code-gen=node> -- ...args: Execute program with given args
 	extract <archive_file> <out_path>: Extract a given archive to directory
 	fetch-deps <server>: Fetch and build all deps (opts: --no-build, --dev)
-	init <namespace> <package>: Initialize a new project with given namespace and package name
+	init <namespace> <package> <template.inigo>: Initialize a new project with given namespace and package name
 	login <server>: Login to an account
 	pull <server> <package_ns> <package_name> <version?>: Pull a package from remote
 	push <server> <pkg_file>: Push a package to remote

--- a/templates/baseDhall.inigo
+++ b/templates/baseDhall.inigo
@@ -1,0 +1,25 @@
+\{file Inigo.dhall}
+{ ns = "\{Namespace}"
+, package = "\{Package}"
+, version = "0.0.1"
+, sourcedir = "."
+, description = None Text
+, executable = Some "\{Package}"
+, modules = ["Main"] : List Text
+, readme = None Text
+, license = None Text
+, link = None Text
+, main = None Text
+, depends = [] : List Text
+, deps = [] : List Text
+, devDeps = [] : List Text
+, localDeps = [] : List Text
+, gitDeps = [] : List { url : Text, commit : Text, subDirs : List Text }
+}
+
+\{file Main.idr}
+module Main
+
+main : IO ()
+main = do
+    putStrLn "Hello from \{Namespace}.\{Package}"

--- a/templates/baseWithTests.inigo
+++ b/templates/baseWithTests.inigo
@@ -1,0 +1,53 @@
+\{file Inigo.toml}
+ns = "\{Package}"
+package= ""
+version= "0.0.1"
+
+description = ""
+link = ""
+readme = ""
+modules = ["Main"]
+depends = []
+license = ""
+main = "Main"
+executable = "\{Package}"
+
+[deps]
+
+[dev-deps]
+Base.IdrTest = "~0.0.1"
+
+\{file Main.idr}
+module Main
+
+main : IO ()
+main = do
+    putStrLn "Hello from \{Namespace}.\{Package}"
+
+\{file Test/Test.idr}
+module Test.Test
+
+import IdrTest.Test
+import IdrTest.Expectation
+
+import Main
+
+export
+suite : Test
+suite =
+  describe "\{Package} tests"
+    [ test "1 == 1" (\\_ => assertEq 1 1 )
+    ]
+
+\{file Test/Suite.idr}
+module Test.Suite
+
+import IdrTest.Test
+
+import Test.Test
+
+suite : IO ()
+suite = do
+  runSuites
+    [ Test.Test.suite
+    ]


### PR DESCRIPTION
These are used for initialising new projects
Currently it is a very simple templating language

`\\` is a literal `\`
`\{` begins a variable or file declaration
`}` ends a variable or file declaration

Variables are:
- Namespace
- Variable

File declarations look like
`\{file ...}`
and begin a file. the file ends at the next file declaration or end of file

There is currently a small limitation, which I plan to remove later
which is file declaration can't contain variables

The parser is a deterministic finite automaton, so it should be quick.

I still have some more todos:
- [ ] allow variables in file declarations. Edit2: I don't know if I actually want this, do you have an opinion on this @alexhumphreys or anyone else?
- [ ] allow installation of templates to a global dir. Edit: I would rather refactor the cli using collie first, so that will come in a later PR