### PR TITLE
Remove dependency on node

### DIFF
--- a/Base/SemVar/SemVar/Data.idr
+++ b/Base/SemVar/SemVar/Data.idr
@@ -129,4 +129,3 @@ satisfy (GT v0) v1 = compare v1 v0 == GT
 satisfy (LTE v0) v1 = v1 `lte` v0
 satisfy (LT v0) v1 = compare v1 v0 == LT
 satisfy (EQ v0) v1 = compare v1 v0 == EQ
-satisfy _ _ = False

--- a/Client/Action/Archive.idr
+++ b/Client/Action/Archive.idr
@@ -4,7 +4,7 @@ import Data.Buffer
 import Data.Maybe
 import Extra.Buffer
 import Inigo.Archive.Archive
-import Inigo.Async.Archive
+-- import Inigo.Async.Archive
 import Inigo.Async.Promise
 import Inigo.Package.Package
 import Inigo.Async.FS

--- a/Client/Action/Build.idr
+++ b/Client/Action/Build.idr
@@ -7,24 +7,23 @@ import Inigo.Package.CodeGen
 import Inigo.Package.Package
 import Inigo.Async.Package
 import Inigo.Paths
+import System.File
 
 export
-writeIPkgFile : Promise Package
-writeIPkgFile =
-  do
-    pkg <- Inigo.Async.Package.currPackage
+writeIPkgFile : Promise String Package
+writeIPkgFile = do
+    pkg <- currPackage
     -- TODO: Only build if not exists ?
-    fs_writeFile inigoIPkgPath (Package.Package.generateIPkg True Nothing pkg)
+    mapErr show $ writeFile inigoIPkgPath (generateIPkg True Nothing pkg)
     pure pkg
 
 export
-runBuild : CodeGen -> Promise ()
+runBuild : CodeGen -> Promise a ()
 runBuild codeGen =
     ignore $ system "idris2" ["--build", inigoIPkgPath, "--cg", toString codeGen] Nothing False True
 
 export
-build : CodeGen -> Promise ()
-build codeGen =
-  do
+build : CodeGen -> Promise String ()
+build codeGen = do
     pkg <- writeIPkgFile
     runBuild codeGen

--- a/Client/Action/BuildDeps.idr
+++ b/Client/Action/BuildDeps.idr
@@ -14,17 +14,16 @@ import Inigo.Paths
 import Inigo.PkgTree
 import SemVar
 
-buildIPkg : String -> Promise ()
-buildIPkg path =
-  do
+buildIPkg : String -> Promise String ()
+buildIPkg path = do
     log (fmt "Compiling %s" (path </> inigoIPkgPath))
     debugLog "[\{path}]$ idris2 --build \{inigoIPkgPath}"
     0 <- system "idris2" ["--build", inigoIPkgPath] (Just path) False True
-        | errno => reject "idris2 build error: \{show errno}"
+        | errno => fail "idris2 build error: \{show errno}"
     log (fmt "Compiled %s" (path </> inigoIPkgPath))
 
 export
-buildDeps : Bool -> Promise ()
+buildDeps : Bool -> Promise String ()
 buildDeps dev = do
     pkgs <- readDepCache
     pkg <- currPackage

--- a/Client/Action/Check.idr
+++ b/Client/Action/Check.idr
@@ -7,8 +7,7 @@ import Inigo.Package.Package
 import Inigo.Paths
 
 export
-check : Promise ()
-check =
-  do
+check : Promise String ()
+check = do
     ignore writeIPkgFile
     ignore $ system "idris2" ["--typecheck", inigoIPkgPath] Nothing False False

--- a/Client/Action/Clean.idr
+++ b/Client/Action/Clean.idr
@@ -8,19 +8,18 @@ import Inigo.Async.Promise
 import Inigo.Async.FS
 import Inigo.Package.Package
 import Inigo.Paths
+import System.File
 
-cleanIPkg : String -> Promise ()
+cleanIPkg : String -> Promise a ()
 cleanIPkg ipkg =
   ignore $ system "idris2" ["--clean", ipkg] Nothing False True
 
 export
-clean : Bool -> Promise ()
-clean deps =
-  do
+clean : Bool -> Promise String ()
+clean deps = do
     ignore writeIPkgFile
     ignore $ cleanIPkg inigoIPkgPath
-    when (deps && !(fs_exists inigoDepDir)) $
-      do
-        files <- fs_getFilesR inigoDepDir
+    when (deps && !(exists inigoDepDir)) $ do
+        files <- mapErr show $ getFilesRec inigoDepDir
         let ipkgs = filter (isSuffixOf ".ipkg") files
-        ignore $ all $ map cleanIPkg ipkgs
+        ignore $ traverse cleanIPkg ipkgs

--- a/Client/Action/Exec.idr
+++ b/Client/Action/Exec.idr
@@ -15,10 +15,9 @@ execDir =
 
 -- TODO: Better handling of base paths
 export
-exec : CodeGen -> Bool -> List String -> Promise ()
-exec codeGen build userArgs =
-  do
-    pkg <- Client.Action.Build.writeIPkgFile
+exec : CodeGen -> Bool -> List String -> Promise String ()
+exec codeGen build userArgs = do
+    pkg <- writeIPkgFile
     when build $ runBuild codeGen
     let Just e = executable pkg
       | Nothing => reject "No executable set in Inigo config"

--- a/Client/Action/Login.idr
+++ b/Client/Action/Login.idr
@@ -5,7 +5,7 @@ import Client.Util
 import Data.Buffer
 import Extra.Buffer
 import Inigo.Async.Base
-import Inigo.Async.Fetch
+-- import Inigo.Async.Fetch
 import Inigo.Async.FS
 import Inigo.Async.Promise
 import Inigo.Util.Url.Url

--- a/Client/Action/Pull.idr
+++ b/Client/Action/Pull.idr
@@ -5,9 +5,9 @@ import Data.Buffer
 import Extra.Buffer
 import Fmt
 import Inigo.Archive.Path
-import Inigo.Async.Archive
+-- import Inigo.Async.Archive
 import Inigo.Async.Base
-import Inigo.Async.Fetch
+-- import Inigo.Async.Fetch
 import Inigo.Async.FS
 import Inigo.Async.Promise
 import Inigo.Package.Package

--- a/Client/Action/Push.idr
+++ b/Client/Action/Push.idr
@@ -5,8 +5,8 @@ import Client.Server
 import Client.Util
 import Data.Buffer
 import Extra.Buffer
-import Inigo.Async.Archive
-import Inigo.Async.Fetch
+-- import Inigo.Async.Archive
+-- import Inigo.Async.Fetch
 import Inigo.Async.FS
 import Inigo.Async.Promise
 import Inigo.Package.Package

--- a/Client/Action/Register.idr
+++ b/Client/Action/Register.idr
@@ -3,7 +3,7 @@ module Client.Action.Register
 import Client.Util
 import Client.Server
 import Data.Buffer
-import Inigo.Async.Fetch
+-- import Inigo.Async.Fetch
 import Inigo.Async.Promise
 import Inigo.Util.Url.Url
 import Toml

--- a/Client/Action/Repl.idr
+++ b/Client/Action/Repl.idr
@@ -7,14 +7,15 @@ import Inigo.Package.CodeGen
 import Inigo.Package.Package
 import Inigo.Async.Package
 import Inigo.Paths
+import System.File
 
-writeIPkgNoExe : Promise ()
+writeIPkgNoExe : Promise String ()
 writeIPkgNoExe = do
     pkg <- currPackage
-    fs_writeFile inigoIPkgPath (generateIPkg False Nothing pkg)
+    mapErr show $ writeFile inigoIPkgPath (generateIPkg False Nothing pkg)
 
 export
-repl : Promise ()
+repl : Promise String ()
 repl = do
     writeIPkgNoExe
     ignore $ systemWithStdIO "idris2" ["--repl", inigoIPkgPath] True True

--- a/Client/Action/Test.idr
+++ b/Client/Action/Test.idr
@@ -9,9 +9,8 @@ import Inigo.Package.Package
 
 -- TODO: Consider moving this out from Inigo into toml config
 export
-test : CodeGen -> Promise ()
-test codeGen =
-  do
-    pkg <- Build.writeIPkgFile
+test : CodeGen -> Promise String ()
+test codeGen = do
+    pkg <- writeIPkgFile
     log (fmt "Running tests...")
     ignore $ system "idris2" ["--find-ipkg", "Test/Suite.idr", "--cg", CodeGen.toString codeGen, "-x", "suite"] Nothing True True

--- a/Client/Client.idr
+++ b/Client/Client.idr
@@ -1,6 +1,6 @@
 module Client.Client
 
-import Client.Action.Archive
+-- import Client.Action.Archive
 import Client.Action.Build
 import Client.Action.BuildDeps
 import Client.Action.Clean
@@ -8,14 +8,14 @@ import Client.Action.Check
 import Client.Action.Exec
 import Client.Action.FetchDeps
 import Client.Action.Init
-import Client.Action.Login
-import Client.Action.Pull
-import Client.Action.Push
-import Client.Action.Register
+-- import Client.Action.Login
+-- import Client.Action.Pull
+-- import Client.Action.Push
+-- import Client.Action.Register
 import Client.Action.Repl
 import Client.Action.Test
-import Client.Server
-import Client.Skeleton.Skeleton
+-- import Client.Server
+-- import Client.Skeleton.Skeleton
 import Client.Util
 import Data.List
 import Data.Maybe
@@ -23,7 +23,7 @@ import Data.String
 import Extra.Either
 import Extra.String
 import Fmt
-import Inigo.Account.Account
+-- import Inigo.Account.Account
 import Inigo.Async.Promise
 import Inigo.Package.CodeGen
 import SemVar
@@ -32,15 +32,13 @@ import System
 ||| TODO: Overall, this should be converted to a
 |||       better dependently-typed CLI system
 fail : String -> IO ()
-fail str =
-  do
+fail str = do
     putStrLn str
     exitFailure
 
 -- Note: not total
 requirePrompt : String -> (String -> List String) -> IO String
-requirePrompt prompt validator =
-  do
+requirePrompt prompt validator = do
     putStr prompt
     x <- map trim $ getLine
     case validator x of
@@ -52,38 +50,40 @@ requirePrompt prompt validator =
           requirePrompt prompt validator
 
 data Action : Type where
-  Archive : String -> String -> Action
+  -- Archive : String -> String -> Action
   Build : CodeGen -> Action
   BuildDeps : Bool -> Action
   Clean : Bool -> Action
   Check : Action
   Exec : CodeGen -> List String -> Action
-  Extract : String -> String -> Action
-  FetchDeps : Server -> Bool -> Bool -> Action
+  -- Extract : String -> String -> Action
+  FetchDeps : {- Server -> -} Bool -> Bool -> Action
   Init :
     String -> -- template file
     String -> -- package ns
     String -> -- package name
     Action
-  Login : Server -> Action
-  Pull : Server -> String -> String -> (Maybe Version) -> Action
-  Push : Server -> String -> Action
-  Register : Server -> Action
+  -- Login : Server -> Action
+  -- Pull : Server -> String -> String -> (Maybe Version) -> Action
+  -- Push : Server -> String -> Action
+  -- Register : Server -> Action
   Repl : Action
   Test : CodeGen -> Action
 
+{-
 fetchDepsAction : String -> Bool -> Bool -> Maybe Action
 fetchDepsAction serverName includeDevDeps build =
   do
     server <- getServer serverName
     pure $ FetchDeps server includeDevDeps build
+-}
 
 getAction : List String -> Maybe Action
-getAction ["archive", packageFile, outFile] =
-  Just (Archive packageFile outFile)
+-- getAction ["archive", packageFile, outFile] =
+--   Just (Archive packageFile outFile)
 
-getAction ["extract", archiveFile, outPath] =
-  Just (Extract archiveFile outPath)
+-- getAction ["extract", archiveFile, outPath] =
+--   Just (Extract archiveFile outPath)
 
 getAction ("build-deps" :: args) =
   let
@@ -126,23 +126,24 @@ getAction ("fetch-deps" :: serverName :: extraArgs) =
     build = not $ any (== "--no-build") extraArgs
     includeDevDeps = any (== "--dev") extraArgs
   in
-    fetchDepsAction serverName includeDevDeps build
+    Just $ FetchDeps includeDevDeps build
+    -- fetchDepsAction serverName includeDevDeps build
 
-getAction ["push", serverName, archive] =
-  do
-    server <- getServer serverName
-    pure $ Push server archive
+-- getAction ["push", serverName, archive] =
+--   do
+--     server <- getServer serverName
+--     pure $ Push server archive
 
-getAction ["pull", serverName, packageNS, packageName] =
-  do
-    server <- getServer serverName
-    pure $ Pull server packageNS packageName Nothing
+-- getAction ["pull", serverName, packageNS, packageName] =
+--   do
+--     server <- getServer serverName
+--     pure $ Pull server packageNS packageName Nothing
 
-getAction ["pull", serverName, packageNS, packageName, versionStr] =
-  do
-    server <- getServer serverName
-    version <- parseVersion versionStr
-    pure $ Pull server packageNS packageName (Just version)
+-- getAction ["pull", serverName, packageNS, packageName, versionStr] =
+--   do
+--     server <- getServer serverName
+--     version <- parseVersion versionStr
+--     pure $ Pull server packageNS packageName (Just version)
 
 getAction ["test", codeGen] =
   do
@@ -152,18 +153,18 @@ getAction ["test", codeGen] =
 getAction ["test"] =
   pure $ Test Node
 
-getAction ["register", serverName] =
-  do
-    server <- getServer serverName
-    pure $ Register server
+-- getAction ["register", serverName] =
+--   do
+--     server <- getServer serverName
+--     pure $ Register server
 
 getAction ["repl"] =
     pure Repl
 
-getAction ["login", serverName] =
-  do
-    server <- getServer serverName
-    pure $ Login server
+-- getAction ["login", serverName] =
+--   do
+--     server <- getServer serverName
+--     pure $ Login server
 
 getAction ["init", packageNS, packageName, tmplFile] =
   Just (Init tmplFile packageNS packageName)
@@ -175,15 +176,15 @@ getActionIO =
   map (getAction . drop 2) getArgs
 
 runAction : Action -> IO ()
-runAction (Archive packageFile outFile) =
-  do
-    putStrLn ("Archiving " ++ packageFile ++ " to " ++ outFile)
-    run (buildArchive packageFile outFile)
+-- runAction (Archive packageFile outFile) =
+--   do
+--     putStrLn ("Archiving " ++ packageFile ++ " to " ++ outFile)
+--     run (buildArchive packageFile outFile)
 
-runAction (Extract archiveFile outPath) =
-  do
-    putStrLn ("Extracting " ++ archiveFile ++ " from " ++ outPath)
-    run (extractArchive archiveFile outPath)
+-- runAction (Extract archiveFile outPath) =
+--   do
+--     putStrLn ("Extracting " ++ archiveFile ++ " from " ++ outPath)
+--     run (extractArchive archiveFile outPath)
 
 runAction (BuildDeps dev) =
   run $ buildDeps dev
@@ -200,41 +201,42 @@ runAction Check =
 runAction (Exec codeGen userArgs) =
   run (exec codeGen True userArgs) -- TODO: Make build a flag
 
-runAction (FetchDeps server includeDevDeps build) =
+runAction (FetchDeps {- server -} includeDevDeps build) =
   do
-    putStrLn ("Feching deps from " ++ toString server ++ (if includeDevDeps then " including dev deps" else ""))
-    run $ fetchAllDeps server includeDevDeps build
+    -- putStrLn ("Feching deps from " ++ toString server ++ (if includeDevDeps then " including dev deps" else ""))
+    putStrLn "Fetching deps\{the String $ if includeDevDeps then " including dev deps" else ""}"
+    run $ fetchAllDeps {- server -} includeDevDeps build
 
-runAction (Push server archive) =
-  do
-    Just session <- readSessionFile
-      | Nothing => fail "Must be logged in to push package."
-    putStrLn ("Pushing " ++ archive ++ " to " ++ toString server)
-    run (push server session archive)
+-- runAction (Push server archive) =
+--   do
+--     Just session <- readSessionFile
+--       | Nothing => fail "Must be logged in to push package."
+--     putStrLn ("Pushing " ++ archive ++ " to " ++ toString server)
+--     run (push server session archive)
 
-runAction (Pull server packageNS packageName mVersion) =
-  do
-    putStrLn (fmt "Pulling %s.%s [%s] from %s" packageNS packageName (show mVersion) (toString server))
-    run (pull server packageNS packageName mVersion)
+-- runAction (Pull server packageNS packageName mVersion) =
+--   do
+--     putStrLn (fmt "Pulling %s.%s [%s] from %s" packageNS packageName (show mVersion) (toString server))
+--     run (pull server packageNS packageName mVersion)
 
-runAction (Register server) =
-  do
-    putStrLn "Welcome to Inigo. Let's create an account."
-    ns <- requirePrompt "Namespace [your username]: " nsValid
-    email <- requirePrompt "Email: " emailValid
-    passphrase <- requirePrompt "Passphrase: " passphraseValid
-    putStrLn (fmt "Creating account %s..." ns)
-    run (registerAccount server ns email passphrase)
+-- runAction (Register server) =
+--   do
+--     putStrLn "Welcome to Inigo. Let's create an account."
+--     ns <- requirePrompt "Namespace [your username]: " nsValid
+--     email <- requirePrompt "Email: " emailValid
+--     passphrase <- requirePrompt "Passphrase: " passphraseValid
+--     putStrLn (fmt "Creating account %s..." ns)
+--     run (registerAccount server ns email passphrase)
 
 runAction Repl = run repl
 
-runAction (Login server) =
-  do
-    putStrLn "Welcome back to Inigo."
-    ns <- requirePrompt "Namespace [your username]: " nsValid
-    passphrase <- requirePrompt "Passphrase: " (const [])
-    putStrLn "Logging in..."
-    run (loginAccount server ns passphrase)
+-- runAction (Login server) =
+--   do
+--     putStrLn "Welcome back to Inigo."
+--     ns <- requirePrompt "Namespace [your username]: " nsValid
+--     passphrase <- requirePrompt "Passphrase: " (const [])
+--     putStrLn "Logging in..."
+--     run (loginAccount server ns passphrase)
 
 runAction (Init tmplFile packageNS packageName) = do
     putStrLn (fmt "Initializing new inigo application %s.%s from template %s" packageNS packageName tmplFile)
@@ -244,19 +246,19 @@ runAction (Test codeGen) =
   run (test codeGen)
 
 short : Action -> String
-short (Archive _ _)     = "archive <pkg_file> <out_file>: Archive a given package"
+-- short (Archive _ _)     = "archive <pkg_file> <out_file>: Archive a given package"
 short (Build _)         = "build <code-gen=node>: Build program under given code gen"
 short (BuildDeps _)     = "build-deps: Build all deps"
 short (Clean _)         = "clean <deps?>: Clean package artifacts, optionally including deps"
 short Check             = "check: Typecheck the project"
 short (Exec _ _)        = "exec <code-gen=node> -- ...args: Execute program with given args"
-short (Extract _ _)     = "extract <archive_file> <out_path>: Extract a given archive to directory"
-short (FetchDeps _ _ _) = "fetch-deps <server>: Fetch and build all deps (opts: --no-build, --dev)"
+-- short (Extract _ _)     = "extract <archive_file> <out_path>: Extract a given archive to directory"
+short (FetchDeps _ _) = "fetch-deps <server>: Fetch and build all deps (opts: --no-build, --dev)"
 short (Init _ _ _)      = "init <namespace> <package> <template.inigo>: Initialize a new project with given namespace and package name"
-short (Login _)         = "login <server>: Login to an account"
-short (Pull _ _ _ _)    = "pull <server> <package_ns> <package_name> <version?>: Pull a package from remote"
-short (Push _ _)        = "push <server> <pkg_file>: Push a package to remote"
-short (Register _)      = "register <server>: Register an account namespace"
+-- short (Login _)         = "login <server>: Login to an account"
+-- short (Pull _ _ _ _)    = "pull <server> <package_ns> <package_name> <version?>: Pull a package from remote"
+-- short (Push _ _)        = "push <server> <pkg_file>: Push a package to remote"
+-- short (Register _)      = "register <server>: Register an account namespace"
 short Repl              = "repl: Launch idris2 repl"
 short (Test _)          = "test: Run tests via IdrTest"
 
@@ -265,19 +267,19 @@ usage =
   let
     descs = join "\n\t" $
       map short
-        [ (Archive "" "")
-        , (Build Node)
+        [ {- (Archive "" "")
+        , -} (Build Node)
         , (BuildDeps False)
         , (Clean False)
         , Check
         , (Exec Node [])
-        , (Extract "" "")
-        , (FetchDeps Prod False False)
+        -- , (Extract "" "")
+        , (FetchDeps {- Prod -} False False)
         , (Init "" "" "")
-        , (Login Prod)
-        , (Pull Prod "" "" Nothing)
-        , (Push Prod "")
-        , (Register Prod)
+        -- , (Login Prod)
+        -- , (Pull Prod "" "" Nothing)
+        -- , (Push Prod "")
+        -- , (Register Prod)
         , Repl
         , (Test Node)
         ]

--- a/Client/Util.idr
+++ b/Client/Util.idr
@@ -8,7 +8,7 @@ import Inigo.Async.Promise
 import System
 import System.File
 import System.Path
-
+{-
 rejectStatus : String -> Int -> Buffer -> Promise a
 rejectStatus url status buf =
   do
@@ -23,13 +23,12 @@ assertOk url result =
     (200, buf) <- result
       | (status, res) => rejectStatus url status res
     pure buf
-
+-}
 
 ||| TODO: Improve home dir
 export
 getHomeDir : IO (Maybe String)
-getHomeDir =
-  do
+getHomeDir = do
     Nothing <- getEnv "INIGO_HOME"
       | Just home => pure $ Just home
     Nothing <- getEnv "HOME"
@@ -38,8 +37,7 @@ getHomeDir =
 
 export
 inigoSessionFile : IO (Maybe String)
-inigoSessionFile =
-  do
+inigoSessionFile = do
     Nothing <- getEnv "INIGO_SESSION"
       | Just sessionFile => pure (Just sessionFile)
     Just homeDir <- getHomeDir
@@ -48,8 +46,7 @@ inigoSessionFile =
 
 export
 readSessionFile : IO (Maybe String)
-readSessionFile =
-  do
+readSessionFile = do
     Just sessionFile <- inigoSessionFile
       | Nothing => pure Nothing
     Right session <- readFile sessionFile

--- a/Inigo/Async/Git.idr
+++ b/Inigo/Async/Git.idr
@@ -4,19 +4,20 @@ import Inigo.Async.Base
 import Inigo.Async.Promise
 import Inigo.Async.FS
 import System.Path
+import System.File
 
 ||| Download a git repository optionally specifying the commit, then remove the .git folder
 ||| Returns `True` iff the file already exists.
 export
-git_downloadTo : (url : String) -> (commit : Maybe String) -> (dest : String) -> Promise Bool
-git_downloadTo url commit dest = do
-    case !(fs_exists dest) of
+downloadTo : (url : String) -> (commit : Maybe String) -> (dest : String) -> Promise FileError Bool
+downloadTo url commit dest = do
+    case !(exists dest) of
         False => do
             ignore $ system "git" ["clone", "-q", "--progress", "--recurse-submodules", url, dest] Nothing False False
             maybe
                 (pure ())
                 (\com => ignore $ system "git" ["checkout", "-q", com] (Just dest) False False)
                 commit
-            fs_rmdir True (dest </> ".git")
+            rmdir True (dest </> ".git")
             pure False
         True => pure True

--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,9 @@ idrall :
 	cp -r idrall/build/ttc/* depends/idrall-0/
 
 inigo : idrall
-	idris2 --build Inigo.ipkg --cg node
-	echo '#!/usr/bin/env node' | cat - build/exec/inigo > temp && mv temp build/exec/inigo
-	chmod +x build/exec/inigo
+	idris2 --build Inigo.ipkg
+	# echo '#!/usr/bin/env node' | cat - build/exec/inigo > temp && mv temp build/exec/inigo
+	# chmod +x build/exec/inigo
 	@echo "Built \"build/exec/inigo\""
 
 install : inigo

--- a/Server/InigoServer/Handler.idr
+++ b/Server/InigoServer/Handler.idr
@@ -11,8 +11,8 @@ import Extra.String
 import Fmt
 import Inigo.Account.Account
 import Inigo.Async.Base
-import Inigo.Async.CloudFlare.KV as KV
-import Inigo.Async.CloudFlare.Worker
+-- import Inigo.Async.CloudFlare.KV as KV
+-- import Inigo.Async.CloudFlare.Worker
 import Inigo.Async.Package
 import Inigo.Async.Promise
 import Inigo.Async.SubtleCrypto.SubtleCrypto
@@ -97,7 +97,7 @@ handleApiPackageIndex =
     pure (200, encodePackageIndex index, [])
 
 orLatestVersion : Maybe Version -> String -> String -> Promise (Maybe Version)
-orLatestVersion (Just v) = const $ const $ lift (Just v)
+orLatestVersion (Just v) = const $ const $ pure $ Just v
 orLatestVersion Nothing = latestVersion
 
 handlePackage : String -> String -> (Maybe Version) -> Promise Response

--- a/Server/InigoServer/KVOps.idr
+++ b/Server/InigoServer/KVOps.idr
@@ -9,7 +9,7 @@ import Extra.String
 import Fmt
 import Inigo.Account.Account as Account
 import Inigo.Async.Base
-import Inigo.Async.CloudFlare.KV
+-- import Inigo.Async.CloudFlare.KV
 import Inigo.Async.SubtleCrypto.SubtleCrypto
 import Inigo.Package.Package
 import Inigo.Package.PackageDeps

--- a/Server/InigoServer/Util.idr
+++ b/Server/InigoServer/Util.idr
@@ -54,7 +54,7 @@ def d f str = f str
 ||| Raise an Either to a promise of its right prong
 export
 expectResult : Show err => Either err a -> Promise a
-expectResult (Right x) = lift x
+expectResult (Right x) = pure x
 expectResult (Left err) = reject (show err)
 
 ||| Raise an Either to a promise of its right prong


### PR DESCRIPTION
* Remove central package repo support
* Remove node support (for now as some base ffi functions are missing)
* Builds on chez/anything with c ffi

I have left unused code in, but commented out for now. If we decide to go back to central package repository this might be useful.